### PR TITLE
feat: support custom motion and layout for live shared elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,92 @@ The screen containing `SharedElement.Live` must stay mounted while the payload i
 
 Ordinary stand-ins hand visibility back to the real elements on the UI thread at animation completion. Live content instead remains visible at its endpoint in the overlay until React reparents it into the destination host; delayed JS cleanup must not hide the only mounted instance.
 
+#### Custom live motion and layout
+
+Use `makeLiveTransition` when the same mounted content needs custom motion. Its
+renderer receives a required `children` value containing the library-owned live
+host. Render those children **exactly once, continuously throughout the
+transition**. Do not replace them with a copy of the payload. Live renderer sides
+expose metrics, style, screen identity, and metadata, but no React `content`.
+TypeScript requires the host input; it cannot prove that your renderer displays it.
+
+```tsx
+import Animated, { interpolate, useAnimatedStyle } from 'react-native-reanimated';
+import {
+  makeLiveTransition,
+  SharedElement,
+  type LiveTransitionRendererProps,
+} from 'react-native-screen-choreography';
+
+function PanelMotion({
+  children, source, target, progress, direction, zIndex,
+}: LiveTransitionRendererProps) {
+  const motion = useAnimatedStyle(() => {
+    const t = direction === 'backward' ? 1 - progress.value : progress.value;
+    return {
+      left: interpolate(t, [0, 1], [source.metrics.pageX, target.metrics.pageX]),
+      top: interpolate(t, [0, 1], [source.metrics.pageY, target.metrics.pageY]),
+      transform: [{ scale: interpolate(t, [0, 1], [
+        source.metrics.width / 240, target.metrics.width / 240,
+      ]) }],
+    };
+  });
+  return (
+    <Animated.View style={[
+      { position: 'absolute', width: 240, height: 160,
+        transformOrigin: 'top left', zIndex },
+      motion,
+    ]}>
+      {children}
+    </Animated.View>
+  );
+}
+
+// Create once, outside render, and reuse on BOTH endpoints.
+const panelMotion = makeLiveTransition({ renderer: PanelMotion });
+
+// Owner: measured endpoint and payload both start at 240 × 160.
+<SharedElement.Live
+  id="panel" groupId="demo" transition={panelMotion}
+  style={{ width: 240, height: 160 }}
+  portalStyle={{ flex: 0, width: 240, height: 160 }}
+>
+  <StatefulPanel />
+</SharedElement.Live>
+
+// Destination: measure 120 × 80, retain 240 × 160 content layout, scale to fit.
+<SharedElement.LiveTarget
+  id="panel" groupId="demo" transition={panelMotion}
+  style={{ width: 120, height: 80 }}
+  hostStyle={{
+    right: undefined, bottom: undefined, width: 240, height: 160,
+    transformOrigin: 'top left', transform: [{ scale: 0.5 }],
+  }}
+/>
+```
+
+The coordinator uses the departing endpoint's transition, including on back
+navigation. Reuse the same transition object at both endpoints for consistent
+motion. If configuration depends on props, memoize the factory result with
+`useMemo`; recreating a renderer identity during a transition can remount its
+host. Custom transitions default to `zIndex: 100`, matching built-in live motion;
+an explicit `zIndex`, including zero, overrides it.
+
+`style` controls the measured endpoint wrapper. `portalStyle` on `Live` overrides
+the portal's default `flex: 1`, `width: '100%'`, and `height: '100%'` layout.
+`hostStyle` on `LiveTarget` overrides its absolute-fill receiving host separately.
+Your renderer's resting geometry must match these endpoints to avoid a jump at
+handoff. This also supports an offscreen one-pixel endpoint with a full-height
+payload and receiving host. Omitting all options keeps built-in live behavior.
+
+Both live endpoints accept `metadata?: unknown`, exposed as `source.metadata`
+and `target.metadata`. Narrow it before use. The library captures each metadata
+reference at session start; replacing it affects the next session. It does not
+deep-clone or freeze application objects. SharedValue references inside metadata
+can continue changing on the UI thread, allowing motion to follow an ongoing
+gesture without inspecting private child props. The same API is exported from
+`/core` and `/expo-router`.
+
 ### 3. Navigate through the choreography hook
 
 `useChoreographyNavigation` pre-measures the source, manages pending target visibility, creates the transition session, and coordinates reverse flows.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ The adapters read navigator state and bind navigation commands and removal inter
 
 The `src/core` directory holds internal runtime machinery, not the public `/core` export surface. `src/components` contains navigator-independent components, including `ChoreographyScreenBase`; `src/hooks` contains shared lifecycle and progress hooks. Rendering recipes, stand-ins, native integration, and logging remain in their respective directories.
 
-[__tests__/entryPoints.test.ts](../__tests__/entryPoints.test.ts) checks that entries contain only exports, that shared value and type exports are identical across integrations, and that their transitive source imports preserve navigation dependency isolation.
+[src/entries/index.test.ts](../src/entries/index.test.ts) checks that entries contain only exports, that shared value and type exports are identical across integrations, and that their transitive source imports preserve navigation dependency isolation.
 
 ## Supported Runtime Model
 
@@ -236,6 +236,24 @@ The shared progress value is the contract between the transition runtime and com
 `ScreenReadinessRegistry` combines screen layout readiness with reference-counted application blockers. `ChoreographyScreen ready={false}` and `useChoreographyBlocker().acquire()` both hold the existing pre-transition readiness wait; neither creates a separate transition lifecycle.
 
 Normal pairs render frozen `ElementPresentation` values. `SharedElement.Live` is a distinct opt-in path: `react-native-teleport` physically reparents one React-owned native subtree into a pair-specific overlay host during animation and into `SharedElement.LiveTarget` at the settled detail endpoint. The original owner must remain mounted, and ordinary shared elements remain preferable when live native state is unnecessary.
+
+`makeLiveTransition` adapts a custom live renderer to that same lifecycle. The
+adapter owns the screen-pair-scoped `PortalHost`, passes it as required children,
+and removes presentation content from the custom renderer's endpoint inputs.
+Its factory result is explicitly live and defaults to zIndex 100. Both endpoints
+accept that result; departing-endpoint transition selection remains unchanged,
+so callers reuse one object for forward and reverse motion. Factory calls belong
+outside render or in a configuration-dependent memo, preserving adapter identity.
+
+Live endpoint metadata is captured by reference with `ElementPresentation` and
+forwarded from the session's frozen presentations. Updating props does not
+re-register an element or alter an active session's captured reference. SharedValue
+objects contained in metadata remain live; there is no deep snapshot. The public
+ordinary `SharedElement` props do not expose the internal metadata plumbing.
+Endpoint wrapper style, live portal style, and receiving host style compose
+independently. Custom renderers are responsible for endpoint geometry continuity;
+host naming, settlement, overlay visibility handoff, and reverse commit timing
+retain the existing lifecycle.
 
 ## Navigation Session Controller
 

--- a/examples/expo-router/README.md
+++ b/examples/expo-router/README.md
@@ -5,6 +5,7 @@ This Expo SDK 57 development-build app demonstrates `react-native-screen-choreog
 - Expo Router's native `Stack`
 - the same gallery, music, wallet, and wallet-setup demos as the React Navigation example
 - a teleport-backed music player with persistent playback state, an animated waveform, and an interactive pull-down handle
+- a custom live renderer that transforms one fixed-layout stateful panel between differently measured Music bounds
 - shared screens, data, transition renderers, styles, and interactive gestures from `examples/shared`
 - thin typed dynamic route adapters such as `/gallery/[photoId]`
 - explicit `ChoreographyScreen` identity
@@ -40,3 +41,5 @@ Expo Go is not supported because the library includes a custom native overlay ho
 Keep `animation: 'none'` and transparent stack content so the choreography overlay owns the visible motion.
 
 In Music, start a track from its list-row play button, open the track, and return using Back or the pull-down handle. The elapsed time and play/pause state stay with the same `SharedElement.Live` instance across both hosts. Playback is simulated; no audio is streamed.
+
+The smaller LIVE INSTANCE panel uses the same module-scope custom transition on its owner and target. Tap `+1`, open the track, and verify its instance number and counter survive the move into the larger destination bounds. Check Back, a short pull-down that cancels, rapid open-close interruption, and repeated open-close cycles. The panel should remain single, continuous, and aligned at both endpoints without flashing or resetting.

--- a/examples/react-navigation/README.md
+++ b/examples/react-navigation/README.md
@@ -12,6 +12,7 @@ This example app exposes the shared gallery, music, wallet, and wallet-setup dem
 - staged reveal of detail content
 - fast push-pop-push interruption handling
 - native view reparenting in Music with one stateful player instance shared between compact and expanded hosts
+- a custom live renderer in Music that moves and scales a fixed-layout stateful panel between differently measured bounds
 - a pull-down handle that supports completing or cancelling an interactive return to the music list
 
 ## Important Runtime Setup
@@ -64,6 +65,8 @@ yarn start
 - `../shared/music/MusicListScreen.tsx` for the `SharedElement.Live` owners
 - `../shared/music/NowPlayingScreen.tsx` for the destination-only `LiveTarget` and pull-down handle
 - `../shared/music/TrackItem.tsx` for the playback clock, waveform, and controls that survive teleporting
+- `../shared/music/liveGeometryTransition.tsx` for the custom live transform and its safely narrowed metadata
+- `../shared/music/LiveGeometryPanel.tsx` for the synthetic mount identity and counter state
 
 The Expo Router app imports those same files. Only navigator setup, destination mapping, and dynamic route parameter extraction remain app-specific.
 
@@ -76,6 +79,10 @@ The Expo Router app imports those same files. Only navigator setup, destination 
 - repeat push-pop cycles to check for flashes, dropped reverses, or large startup delays
 - start a track from the Music list, open its artwork/title, and verify the elapsed time continues in Now Playing
 - pause, return to the list, and reopen the same track; its elapsed time and play/pause state should not reset
+- tap `+1` on a track's LIVE INSTANCE panel, open that track, and verify the same instance number and counter arrive without an endpoint jump
+- press Back and verify the panel returns to its compact bounds with the same state
+- drag the music handle a short distance and release to cancel; verify the panel returns to the expanded bounds without remounting
+- rapidly open and close a track, then repeat several cycles; verify the panel never duplicates, flashes, or resets
 - pull the music handle down a little and release to cancel, then pull farther to return to the list
 
 Music simulates playback with a clock and animated waveform; it does not play audio. Each track's live component owns its state while the Music list stays mounted.

--- a/examples/shared/music/LiveGeometryPanel.tsx
+++ b/examples/shared/music/LiveGeometryPanel.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { theme } from '../theme';
+import type { Track } from './data';
+
+let nextInstanceId = 1;
+
+export function LiveGeometryPanel({ track }: { track: Track }) {
+  const [instanceId] = useState(() => nextInstanceId++);
+  const [count, setCount] = useState(0);
+
+  return (
+    <View style={styles.panel} testID={`live-geometry-${track.id}`}>
+      <View style={styles.copy}>
+        <Text style={styles.eyebrow}>LIVE INSTANCE {instanceId}</Text>
+        <Text style={styles.title} numberOfLines={1}>
+          {track.title}
+        </Text>
+        <Text style={styles.state}>STATE {count}</Text>
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={`Increment live state for ${track.title}`}
+        onPress={() => setCount((value) => value + 1)}
+        style={({ pressed }) => [
+          styles.button,
+          pressed && styles.buttonPressed,
+        ]}
+      >
+        <Text style={styles.buttonLabel}>+1</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  panel: {
+    width: 160,
+    height: 64,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    backgroundColor: '#172033',
+    borderWidth: 1,
+    borderColor: '#3a4f78',
+    boxShadow: '0 5px 14px rgba(0, 0, 0, 0.28)',
+  },
+  copy: {
+    flex: 1,
+    minWidth: 0,
+  },
+  eyebrow: {
+    color: '#8eabd7',
+    fontFamily: theme.numbers,
+    fontSize: 7,
+    fontWeight: '700',
+  },
+  title: {
+    color: theme.text,
+    fontFamily: theme.font,
+    fontSize: 10,
+    fontWeight: '600',
+    marginTop: 2,
+  },
+  state: {
+    color: theme.textSecondary,
+    fontFamily: theme.numbers,
+    fontSize: 8,
+    marginTop: 2,
+  },
+  button: {
+    width: 34,
+    height: 34,
+    marginLeft: 8,
+    borderRadius: 17,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.music.accent,
+  },
+  buttonPressed: {
+    opacity: 0.72,
+  },
+  buttonLabel: {
+    color: theme.bg,
+    fontFamily: theme.numbers,
+    fontSize: 12,
+    fontWeight: '700',
+  },
+});

--- a/examples/shared/music/MusicListScreen.tsx
+++ b/examples/shared/music/MusicListScreen.tsx
@@ -5,6 +5,13 @@ import { theme } from '../theme';
 import { TRACKS, type Track } from './data';
 import { musicBackgroundTransition } from './musicTransitions';
 import { TrackItem } from './TrackItem';
+import { LiveGeometryPanel } from './LiveGeometryPanel';
+import {
+  LIVE_GEOMETRY_HEIGHT,
+  LIVE_GEOMETRY_WIDTH,
+  liveGeometryMetadata,
+  liveGeometryTransition,
+} from './liveGeometryTransition';
 
 export function MusicListScreen() {
   const { goBack, navigate } = useExampleNavigation();
@@ -83,6 +90,17 @@ function Row({ track, onPress }: { track: Track; onPress: () => void }) {
         >
           <TrackItem track={track} onOpen={onPress} />
         </SharedElement.Live>
+
+        <SharedElement.Live
+          id="geometry-panel"
+          groupId={groupId}
+          transition={liveGeometryTransition}
+          metadata={liveGeometryMetadata}
+          style={styles.geometryBounds}
+          portalStyle={styles.geometryPortal}
+        >
+          <LiveGeometryPanel track={track} />
+        </SharedElement.Live>
       </View>
     </View>
   );
@@ -150,7 +168,7 @@ const styles = StyleSheet.create({
     borderBottomColor: theme.border,
   },
   row: {
-    height: 76,
+    height: 152,
     position: 'relative',
   },
   rowBackground: {
@@ -160,7 +178,23 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   itemLayer: {
-    ...StyleSheet.absoluteFill,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 76,
+  },
+  geometryBounds: {
+    position: 'absolute',
+    left: 12,
+    bottom: 6,
+    width: LIVE_GEOMETRY_WIDTH,
+    height: LIVE_GEOMETRY_HEIGHT,
+  },
+  geometryPortal: {
+    flex: 0,
+    width: LIVE_GEOMETRY_WIDTH,
+    height: LIVE_GEOMETRY_HEIGHT,
   },
   fill: {
     flex: 1,

--- a/examples/shared/music/NowPlayingScreen.tsx
+++ b/examples/shared/music/NowPlayingScreen.tsx
@@ -5,6 +5,14 @@ import { TRACKS } from './data';
 import { musicBackgroundTransition } from './musicTransitions';
 import { IconButton } from '../AppChrome';
 import { InteractiveBackGesture } from '../InteractiveBackGesture';
+import {
+  LIVE_GEOMETRY_HEIGHT,
+  LIVE_GEOMETRY_TARGET_HEIGHT,
+  LIVE_GEOMETRY_TARGET_WIDTH,
+  LIVE_GEOMETRY_WIDTH,
+  liveGeometryMetadata,
+  liveGeometryTransition,
+} from './liveGeometryTransition';
 
 export function NowPlayingScreen({
   trackId = TRACKS[0]!.id,
@@ -51,6 +59,15 @@ export function NowPlayingScreen({
                 id="item"
                 groupId={groupId}
                 style={styles.player}
+              />
+
+              <SharedElement.LiveTarget
+                id="geometry-panel"
+                groupId={groupId}
+                transition={liveGeometryTransition}
+                metadata={liveGeometryMetadata}
+                style={styles.geometryTarget}
+                hostStyle={styles.geometryHost}
               />
             </View>
           </SafeAreaView>
@@ -103,4 +120,22 @@ const styles = StyleSheet.create({
   },
   card: { flex: 1, marginHorizontal: 16, marginTop: 56 },
   player: { flex: 1 },
+  geometryTarget: {
+    width: LIVE_GEOMETRY_TARGET_WIDTH,
+    height: LIVE_GEOMETRY_TARGET_HEIGHT,
+    alignSelf: 'center',
+    marginTop: 12,
+    marginBottom: 20,
+  },
+  geometryHost: {
+    right: 'auto',
+    bottom: 'auto',
+    width: LIVE_GEOMETRY_WIDTH,
+    height: LIVE_GEOMETRY_HEIGHT,
+    transformOrigin: 'top left',
+    transform: [
+      { scaleX: LIVE_GEOMETRY_TARGET_WIDTH / LIVE_GEOMETRY_WIDTH },
+      { scaleY: LIVE_GEOMETRY_TARGET_HEIGHT / LIVE_GEOMETRY_HEIGHT },
+    ],
+  },
 });

--- a/examples/shared/music/liveGeometryTransition.tsx
+++ b/examples/shared/music/liveGeometryTransition.tsx
@@ -1,0 +1,136 @@
+import { StyleSheet } from 'react-native';
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useDerivedValue,
+} from 'react-native-reanimated';
+import type { LiveTransitionRendererProps } from 'react-native-screen-choreography/core';
+import { makeLiveTransition } from '../runtime';
+
+export const LIVE_GEOMETRY_WIDTH = 160;
+export const LIVE_GEOMETRY_HEIGHT = 64;
+export const LIVE_GEOMETRY_TARGET_WIDTH = 280;
+export const LIVE_GEOMETRY_TARGET_HEIGHT = 112;
+
+export const liveGeometryMetadata = {
+  kind: 'music-live-geometry',
+  layoutWidth: LIVE_GEOMETRY_WIDTH,
+  layoutHeight: LIVE_GEOMETRY_HEIGHT,
+} as const;
+
+function readLiveGeometryMetadata(
+  value: unknown
+): { layoutWidth: number; layoutHeight: number } | null {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'kind' in value &&
+    value.kind === liveGeometryMetadata.kind &&
+    'layoutWidth' in value &&
+    typeof value.layoutWidth === 'number' &&
+    Number.isFinite(value.layoutWidth) &&
+    value.layoutWidth > 0 &&
+    'layoutHeight' in value &&
+    typeof value.layoutHeight === 'number' &&
+    Number.isFinite(value.layoutHeight) &&
+    value.layoutHeight > 0
+  ) {
+    return {
+      layoutWidth: value.layoutWidth,
+      layoutHeight: value.layoutHeight,
+    };
+  }
+  return null;
+}
+
+function LiveGeometryRenderer({
+  children,
+  progress,
+  direction,
+  source,
+  target,
+  zIndex,
+}: LiveTransitionRendererProps) {
+  const sourceLayout = readLiveGeometryMetadata(source.metadata);
+  const targetLayout = readLiveGeometryMetadata(target.metadata);
+  const metadataMatches =
+    sourceLayout &&
+    targetLayout &&
+    sourceLayout.layoutWidth === targetLayout.layoutWidth &&
+    sourceLayout.layoutHeight === targetLayout.layoutHeight;
+  const layoutWidth = metadataMatches
+    ? sourceLayout.layoutWidth
+    : LIVE_GEOMETRY_WIDTH;
+  const layoutHeight = metadataMatches
+    ? sourceLayout.layoutHeight
+    : LIVE_GEOMETRY_HEIGHT;
+  const t = useDerivedValue(() =>
+    direction === 'backward' ? 1 - progress.value : progress.value
+  );
+  const animatedStyle = useAnimatedStyle(() => ({
+    left: interpolate(
+      t.value,
+      [0, 1],
+      [source.metrics.pageX, target.metrics.pageX],
+      'clamp'
+    ),
+    top: interpolate(
+      t.value,
+      [0, 1],
+      [source.metrics.pageY, target.metrics.pageY],
+      'clamp'
+    ),
+    transform: [
+      {
+        scaleX: interpolate(
+          t.value,
+          [0, 1],
+          [
+            source.metrics.width / layoutWidth,
+            target.metrics.width / layoutWidth,
+          ],
+          'clamp'
+        ),
+      },
+      {
+        scaleY: interpolate(
+          t.value,
+          [0, 1],
+          [
+            source.metrics.height / layoutHeight,
+            target.metrics.height / layoutHeight,
+          ],
+          'clamp'
+        ),
+      },
+      {
+        rotateZ: `${interpolate(t.value, [0, 0.5, 1], [0, -3, 0], 'clamp')}deg`,
+      },
+    ],
+  }));
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.portal,
+        { width: layoutWidth, height: layoutHeight, zIndex },
+        animatedStyle,
+      ]}
+    >
+      {children}
+    </Animated.View>
+  );
+}
+
+export const liveGeometryTransition = makeLiveTransition({
+  renderer: LiveGeometryRenderer,
+  zIndex: 4,
+});
+
+const styles = StyleSheet.create({
+  portal: {
+    position: 'absolute',
+    transformOrigin: 'top left',
+  },
+});

--- a/examples/shared/runtime.tsx
+++ b/examples/shared/runtime.tsx
@@ -17,6 +17,7 @@ import type { SharedValue } from 'react-native-reanimated';
 export {
   SharedElement,
   StandInContainer,
+  makeLiveTransition,
   makeStretchTransition,
   makeSurfaceTransition,
   textMorphTransition,

--- a/src/components/SharedElement.live.test.tsx
+++ b/src/components/SharedElement.live.test.tsx
@@ -1,0 +1,310 @@
+import { StyleSheet, View } from 'react-native';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type {
+  ElementTransitionPair,
+  LiveTransition,
+  RegisteredElement,
+  TransitionSessionData,
+} from '../types';
+import {
+  ChoreographyActionsContext,
+  ChoreographyContext,
+  type ChoreographyActionsType,
+  type ChoreographyContextType,
+} from '../core/ChoreographyContext';
+import { ScreenIdContext } from '../core/screenIdContext';
+import { makeLiveTransition } from '../transitions/makeLiveTransition';
+import { SharedElement } from './SharedElement';
+
+jest.mock('react-native-reanimated', () => {
+  const { useRef } = jest.requireActual('react');
+  return {
+    ...jest.requireActual('../../__mocks__/react-native-reanimated'),
+    __esModule: true,
+    useAnimatedRef: () => useRef(() => {}).current,
+  };
+});
+jest.mock('react-native-teleport', () => ({
+  Portal: 'Portal',
+  PortalHost: 'PortalHost',
+}));
+
+const { Portal, PortalHost } = jest.requireMock('react-native-teleport') as {
+  Portal: React.ElementType;
+  PortalHost: React.ElementType;
+};
+const AnimatedView = 'Animated.View' as React.ElementType;
+
+const noopTransition = makeLiveTransition({ renderer: () => null });
+
+function session(
+  sourceScreenId: string,
+  targetScreenId: string,
+  direction: TransitionSessionData['direction'] = 'forward'
+): TransitionSessionData {
+  const endpoint = (screenId: string) =>
+    ({ screenId, groupId: 'media' }) as RegisteredElement;
+  return {
+    id: `${sourceScreenId}->${targetScreenId}`,
+    groupId: 'media',
+    sourceScreenId,
+    targetScreenId,
+    state: 'active',
+    direction,
+    progress: {
+      value: direction === 'forward' ? 0 : 1,
+    } as TransitionSessionData['progress'],
+    pairs: [
+      {
+        id: 'player',
+        source: endpoint(sourceScreenId),
+        target: endpoint(targetScreenId),
+      } as ElementTransitionPair,
+    ],
+  };
+}
+
+function makeContexts() {
+  let settledScreenId: string | null = null;
+  const registered: RegisteredElement[] = [];
+  const actions = {
+    registerElement: jest.fn((element: RegisteredElement) => {
+      registered.push(element);
+    }),
+    unregisterElement: jest.fn(),
+    isElementHidden: jest.fn(() => ({ value: 0 })),
+    getSettledScreenId: jest.fn(() => settledScreenId),
+  } as unknown as ChoreographyActionsType;
+  return {
+    actions,
+    registered,
+    settle(screenId: string) {
+      settledScreenId = screenId;
+    },
+  };
+}
+
+function choreography(
+  activeSession: TransitionSessionData | null
+): ChoreographyContextType {
+  return { activeSession } as ChoreographyContextType;
+}
+
+describe('SharedElement live endpoints', () => {
+  test('uses the default transition and applies endpoint portal and host styles', async () => {
+    const state = makeContexts();
+    let tree!: ReactTestRenderer;
+
+    try {
+      await act(async () => {
+        tree = create(
+          <ChoreographyActionsContext.Provider value={state.actions}>
+            <ChoreographyContext.Provider value={choreography(null)}>
+              <ScreenIdContext.Provider value="list-instance">
+                <SharedElement.Live
+                  id="player"
+                  groupId="media"
+                  style={{ width: 240, height: 160 }}
+                  portalStyle={{
+                    flex: 0,
+                    width: 320,
+                    height: 200,
+                    backgroundColor: 'red',
+                  }}
+                >
+                  <View testID="player-content" />
+                </SharedElement.Live>
+              </ScreenIdContext.Provider>
+              <ScreenIdContext.Provider value="detail-instance">
+                <SharedElement.LiveTarget
+                  id="player"
+                  groupId="media"
+                  style={{ width: 1, height: 1 }}
+                  hostStyle={{
+                    width: 280,
+                    height: 180,
+                    backgroundColor: 'blue',
+                  }}
+                />
+              </ScreenIdContext.Provider>
+            </ChoreographyContext.Provider>
+          </ChoreographyActionsContext.Provider>
+        );
+      });
+
+      expect(state.registered).toHaveLength(2);
+      for (const element of state.registered) {
+        expect(element.getPresentation().transition).toMatchObject({
+          mode: 'live',
+          zIndex: 100,
+        });
+      }
+      expect(
+        StyleSheet.flatten(tree.root.findByType(Portal).props.style)
+      ).toMatchObject({
+        flex: 0,
+        width: 320,
+        height: 200,
+        backgroundColor: 'red',
+      });
+      const host = tree.root.findByType(PortalHost);
+      expect(host.props.name).toBe(
+        'screen-choreography:live:destination:["detail-instance","media","player"]'
+      );
+      expect(StyleSheet.flatten(host.props.style)).toMatchObject({
+        position: 'absolute',
+        top: 0,
+        width: 280,
+        height: 180,
+        backgroundColor: 'blue',
+      });
+      const wrappers = tree.root.findAllByType(AnimatedView);
+      expect(StyleSheet.flatten(wrappers[0]!.props.style)).toMatchObject({
+        width: 240,
+        height: 160,
+      });
+      expect(StyleSheet.flatten(wrappers[1]!.props.style)).toMatchObject({
+        width: 1,
+        height: 1,
+      });
+    } finally {
+      await act(async () => tree?.unmount());
+    }
+  });
+
+  test('keeps registration stable while renderer and metadata snapshots advance', async () => {
+    const state = makeContexts();
+    const firstTransition = makeLiveTransition({ renderer: () => null });
+    const secondRenderer = () => null;
+    const secondTransition = makeLiveTransition({
+      renderer: secondRenderer,
+      zIndex: 222,
+    });
+    let tree!: ReactTestRenderer;
+    const render = (transition: LiveTransition, version: number) => (
+      <ChoreographyActionsContext.Provider value={state.actions}>
+        <ChoreographyContext.Provider value={choreography(null)}>
+          <ScreenIdContext.Provider value="list">
+            <SharedElement.Live
+              id="player"
+              groupId="media"
+              transition={transition}
+              metadata={{ version }}
+            >
+              <View testID={`content-${version}`} />
+            </SharedElement.Live>
+          </ScreenIdContext.Provider>
+        </ChoreographyContext.Provider>
+      </ChoreographyActionsContext.Provider>
+    );
+
+    try {
+      await act(async () => {
+        tree = create(render(firstTransition, 1));
+      });
+      const registration = state.registered[0]!;
+      const initialGetPresentation = registration.getPresentation;
+      expect(registration.getPresentation()).toMatchObject({
+        transition: firstTransition,
+        metadata: { version: 1 },
+      });
+
+      await act(async () => {
+        tree.update(render(secondTransition, 2));
+      });
+
+      expect(state.actions.registerElement).toHaveBeenCalledTimes(1);
+      expect(state.actions.unregisterElement).not.toHaveBeenCalled();
+      expect(registration.getPresentation).toBe(initialGetPresentation);
+      expect(registration.getPresentation()).toMatchObject({
+        transition: secondTransition,
+        metadata: { version: 2 },
+      });
+      expect(registration.getPresentation().transition.renderer).toBe(
+        secondTransition.renderer
+      );
+      expect(tree.root.findByProps({ testID: 'content-2' })).toBeDefined();
+    } finally {
+      await act(async () => tree?.unmount());
+    }
+  });
+
+  test('routes forward, backward, cancelled, rapid, and repeated sessions without stale hosts', async () => {
+    const state = makeContexts();
+    let tree!: ReactTestRenderer;
+    const render = (activeSession: TransitionSessionData | null) => (
+      <ChoreographyActionsContext.Provider value={state.actions}>
+        <ChoreographyContext.Provider value={choreography(activeSession)}>
+          <ScreenIdContext.Provider value="list">
+            <SharedElement.Live
+              id="player"
+              groupId="media"
+              transition={noopTransition}
+            >
+              <View />
+            </SharedElement.Live>
+          </ScreenIdContext.Provider>
+        </ChoreographyContext.Provider>
+      </ChoreographyActionsContext.Provider>
+    );
+    const hostName = () => tree.root.findByType(Portal).props.hostName;
+
+    try {
+      await act(async () => {
+        tree = create(render(null));
+      });
+      expect(hostName()).toBeUndefined();
+
+      await act(async () => tree.update(render(session('list', 'detail'))));
+      expect(hostName()).toBe(
+        'screen-choreography:live:overlay:["list","detail","media","player"]'
+      );
+
+      // A rapid reversal must immediately use its own pair host.
+      await act(async () =>
+        tree.update(render(session('detail', 'list', 'backward')))
+      );
+      expect(hostName()).toBe(
+        'screen-choreography:live:overlay:["detail","list","media","player"]'
+      );
+      state.settle('list');
+      await act(async () => tree.update(render(null)));
+      expect(hostName()).toBeUndefined();
+
+      // Repeated forward settlement reparents to the named target host.
+      await act(async () => tree.update(render(session('list', 'detail'))));
+      state.settle('detail');
+      await act(async () => tree.update(render(null)));
+      expect(hostName()).toBe(
+        'screen-choreography:live:destination:["detail","media","player"]'
+      );
+
+      // Backward cancellation stays on detail, its source screen.
+      await act(async () =>
+        tree.update(render(session('detail', 'list', 'backward')))
+      );
+      state.settle('detail');
+      await act(async () => tree.update(render(null)));
+      expect(hostName()).toBe(
+        'screen-choreography:live:destination:["detail","media","player"]'
+      );
+
+      // Backward completion returns ownership to the original portal.
+      await act(async () =>
+        tree.update(render(session('detail', 'list', 'backward')))
+      );
+      state.settle('list');
+      await act(async () => tree.update(render(null)));
+      expect(hostName()).toBeUndefined();
+
+      // Forward cancellation settles on the source and also restores it.
+      await act(async () => tree.update(render(session('list', 'detail'))));
+      state.settle('list');
+      await act(async () => tree.update(render(null)));
+      expect(hostName()).toBeUndefined();
+      expect(state.actions.registerElement).toHaveBeenCalledTimes(1);
+    } finally {
+      await act(async () => tree?.unmount());
+    }
+  });
+});

--- a/src/components/SharedElement.tsx
+++ b/src/components/SharedElement.tsx
@@ -1,4 +1,5 @@
 import React, {
+  type ReactNode,
   useRef,
   useEffect,
   useCallback,
@@ -7,23 +8,26 @@ import React, {
 } from 'react';
 import { type StyleProp, type ViewStyle, StyleSheet } from 'react-native';
 import Animated, {
-  interpolate,
   useAnimatedRef,
   useAnimatedStyle,
-  useDerivedValue,
 } from 'react-native-reanimated';
 import { Portal, PortalHost } from 'react-native-teleport';
 import type {
   ElementPresentation,
+  LiveTransition,
   SharedElementTransition,
-  SharedElementTransitionRendererProps,
 } from '../types';
 import {
   ChoreographyActionsContext,
   ChoreographyContext,
 } from '../core/ChoreographyContext';
-import { getExpansionProgress } from '../core/expansionProgress';
 import { useScreenId } from '../core/screenIdContext';
+import {
+  getLiveDestinationHostName,
+  getLiveOverlayHostName,
+  getLivePortalName,
+} from '../core/liveHostNames';
+import { defaultLiveTransition } from '../transitions/makeLiveTransition';
 
 interface SharedElementTargetContextValue {
   setTarget: (
@@ -54,99 +58,34 @@ export interface SharedElementProps {
   style?: StyleProp<ViewStyle>;
 }
 
-export interface LiveSharedElementProps extends Omit<
-  SharedElementProps,
-  'transition'
-> {}
+export interface LiveSharedElementProps {
+  id: string;
+  groupId?: string;
+  /** Reuse the same factory result on both live endpoints, including for back. */
+  transition?: LiveTransition;
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+  /** Payload layout overrides, applied after the portal's fill defaults. */
+  portalStyle?: StyleProp<ViewStyle>;
+  /** Captured by reference at session start; narrow in the live renderer. */
+  metadata?: unknown;
+}
 
 export interface LiveSharedElementTargetProps {
   id: string;
   groupId?: string;
+  /** Reuse the owner's factory result for consistent forward and back motion. */
+  transition?: LiveTransition;
   style?: StyleProp<ViewStyle>;
+  /** Receiving host layout, independent of the measured wrapper's style. */
+  hostStyle?: StyleProp<ViewStyle>;
+  /** Captured by reference at session start; narrow in the live renderer. */
+  metadata?: unknown;
 }
 
-function getLiveDestinationHostName(
-  screenId: string,
-  id: string,
-  groupId?: string
-) {
-  return `screen-choreography:live:destination:${JSON.stringify([screenId, groupId, id])}`;
+interface SharedElementRegistrationProps extends SharedElementProps {
+  metadata?: unknown;
 }
-
-function getLiveOverlayHostName(
-  sourceScreenId: string,
-  targetScreenId: string,
-  id: string,
-  groupId: string
-) {
-  return `screen-choreography:live:overlay:${JSON.stringify([sourceScreenId, targetScreenId, groupId, id])}`;
-}
-
-function LiveSharedElementRenderer({
-  id,
-  groupId,
-  progress,
-  direction,
-  source,
-  target,
-  zIndex,
-}: SharedElementTransitionRendererProps) {
-  const sourceX = source.metrics.pageX;
-  const sourceY = source.metrics.pageY;
-  const sourceWidth = source.metrics.width;
-  const sourceHeight = source.metrics.height;
-  const targetX = target.metrics.pageX;
-  const targetY = target.metrics.pageY;
-  const targetWidth = target.metrics.width;
-  const targetHeight = target.metrics.height;
-  const timeline = useDerivedValue(() =>
-    direction === 'backward' ? 1 - progress.value : progress.value
-  );
-  const animatedStyle = useAnimatedStyle(() => {
-    const heightProgress = getExpansionProgress(
-      timeline.value,
-      sourceHeight,
-      targetHeight
-    );
-
-    return {
-      left: interpolate(timeline.value, [0, 1], [sourceX, targetX], 'clamp'),
-      top: interpolate(timeline.value, [0, 1], [sourceY, targetY], 'clamp'),
-      width: interpolate(
-        timeline.value,
-        [0, 1],
-        [sourceWidth, targetWidth],
-        'clamp'
-      ),
-      height: interpolate(
-        heightProgress,
-        [0, 1],
-        [sourceHeight, targetHeight],
-        'clamp'
-      ),
-    };
-  });
-
-  return (
-    <Animated.View style={[styles.liveOverlayHost, { zIndex }, animatedStyle]}>
-      <PortalHost
-        name={getLiveOverlayHostName(
-          source.screenId,
-          target.screenId,
-          id,
-          groupId
-        )}
-        style={styles.liveHost}
-      />
-    </Animated.View>
-  );
-}
-
-const liveSharedElementTransition: SharedElementTransition = {
-  zIndex: 100,
-  mode: 'live',
-  renderer: LiveSharedElementRenderer,
-};
 
 /**
  * Wraps content participating in a shared transition. Registration is
@@ -154,13 +93,14 @@ const liveSharedElementTransition: SharedElementTransition = {
  * `ElementPresentation` via `getPresentation()` at session start, so re-renders or
  * prop changes never affect an in-flight overlay.
  */
-function SharedElementRoot({
+function SharedElementRegistration({
   id,
   groupId,
   transition,
   children,
   style,
-}: SharedElementProps) {
+  metadata,
+}: SharedElementRegistrationProps) {
   const viewNodeRef = useRef<any>(null);
   const animatedRef = useAnimatedRef<any>();
   const targetNodeRef = useRef<any>(null);
@@ -188,11 +128,14 @@ function SharedElementRoot({
   transitionRef.current = transition;
   const styleRef = useRef<ViewStyle | undefined>(flattenedStyle);
   styleRef.current = flattenedStyle;
+  const metadataRef = useRef<unknown>(metadata);
+  metadataRef.current = metadata;
   const getPresentation = useCallback<() => ElementPresentation>(
     () => ({
       content: childrenRef.current,
       style: styleRef.current,
       transition: transitionRef.current,
+      metadata: metadataRef.current,
     }),
     []
   );
@@ -270,6 +213,10 @@ function SharedElementRoot({
   );
 }
 
+function SharedElementRoot(props: SharedElementProps) {
+  return <SharedElementRegistration {...props} />;
+}
+
 function SharedElementTarget({ children, style }: SharedElementTargetProps) {
   const target = useContext(SharedElementTargetContext);
   if (!target) {
@@ -297,6 +244,9 @@ function LiveSharedElement({
   groupId,
   children,
   style,
+  transition = defaultLiveTransition,
+  portalStyle,
+  metadata,
 }: LiveSharedElementProps) {
   const choreography = useContext(ChoreographyContext);
   const actions = useContext(ChoreographyActionsContext);
@@ -343,20 +293,21 @@ function LiveSharedElement({
   }
 
   return (
-    <SharedElementRoot
+    <SharedElementRegistration
       id={id}
       groupId={groupId}
-      transition={liveSharedElementTransition}
+      transition={transition}
       style={style}
+      metadata={metadata}
     >
       <Portal
         hostName={hostName}
-        name={`screen-choreography:live:${JSON.stringify([screenId, groupId, id])}`}
-        style={styles.livePortal}
+        name={getLivePortalName(screenId, id, groupId)}
+        style={[styles.livePortal, portalStyle]}
       >
         {children}
       </Portal>
-    </SharedElementRoot>
+    </SharedElementRegistration>
   );
 }
 
@@ -364,20 +315,24 @@ function LiveSharedElementTarget({
   id,
   groupId,
   style,
+  transition = defaultLiveTransition,
+  hostStyle,
+  metadata,
 }: LiveSharedElementTargetProps) {
   const screenId = useScreenId();
   return (
-    <SharedElementRoot
+    <SharedElementRegistration
       id={id}
       groupId={groupId}
-      transition={liveSharedElementTransition}
+      transition={transition}
       style={style}
+      metadata={metadata}
     >
       <PortalHost
         name={getLiveDestinationHostName(screenId, id, groupId)}
-        style={styles.liveHost}
+        style={[styles.liveHost, hostStyle]}
       />
-    </SharedElementRoot>
+    </SharedElementRegistration>
   );
 }
 
@@ -389,10 +344,6 @@ export const SharedElement = Object.assign(SharedElementRoot, {
 
 const styles = StyleSheet.create({
   wrapper: {},
-  liveOverlayHost: {
-    position: 'absolute',
-    overflow: 'hidden',
-  },
   liveHost: {
     ...StyleSheet.absoluteFill,
   },

--- a/src/core/TransitionCoordinator.test.ts
+++ b/src/core/TransitionCoordinator.test.ts
@@ -58,11 +58,13 @@ describe('TransitionCoordinator presentation freezing', () => {
   });
 
   test('captures source/target presentations once at session start', async () => {
+    const liveValue = { value: 0 };
     const sourcePresentation: { current: ElementPresentation } = {
       current: {
         content: 'source-v1',
         style: { backgroundColor: 'red' },
         transition,
+        metadata: { revision: 1, liveValue },
       },
     };
     const targetPresentation: { current: ElementPresentation } = {
@@ -70,6 +72,7 @@ describe('TransitionCoordinator presentation freezing', () => {
         content: 'target-v1',
         style: { backgroundColor: 'blue' },
         transition,
+        metadata: { revision: 10 },
       },
     };
 
@@ -133,6 +136,11 @@ describe('TransitionCoordinator presentation freezing', () => {
     expect(pair.targetPresentation.content).toBe('target-v1');
     expect(pair.sourcePresentation.style?.backgroundColor).toBe('red');
     expect(pair.targetPresentation.style?.backgroundColor).toBe('blue');
+    expect(pair.sourcePresentation.metadata).toEqual({
+      revision: 1,
+      liveValue,
+    });
+    expect(pair.targetPresentation.metadata).toEqual({ revision: 10 });
 
     // Mutating the underlying SharedElement state AFTER the session started
     // must NOT affect what the overlay renders — the snapshot is frozen.
@@ -140,17 +148,31 @@ describe('TransitionCoordinator presentation freezing', () => {
       content: 'source-v2',
       style: { backgroundColor: 'green' },
       transition,
+      metadata: { revision: 2, liveValue: { value: 999 } },
     };
     targetPresentation.current = {
       content: 'target-v2',
       style: { backgroundColor: 'yellow' },
       transition,
+      metadata: { revision: 11 },
     };
 
     expect(pair.sourcePresentation.content).toBe('source-v1');
     expect(pair.targetPresentation.content).toBe('target-v1');
     expect(pair.sourcePresentation.style?.backgroundColor).toBe('red');
     expect(pair.targetPresentation.style?.backgroundColor).toBe('blue');
+    expect(pair.sourcePresentation.metadata).toEqual({
+      revision: 1,
+      liveValue,
+    });
+    expect(pair.targetPresentation.metadata).toEqual({ revision: 10 });
+
+    // Frozen metadata can deliberately retain a SharedValue-like live ref.
+    liveValue.value = 0.625;
+    expect(
+      (pair.sourcePresentation.metadata as { liveValue: { value: number } })
+        .liveValue.value
+    ).toBe(0.625);
   }, 5000);
 
   test('hidden elements are released after completeTransition', async () => {
@@ -206,6 +228,13 @@ describe('TransitionCoordinator presentation freezing', () => {
     const snap: { current: ElementPresentation } = {
       current: { content: null, transition: liveTransition },
     };
+    const targetTransition: SharedElementTransition = {
+      renderer: () => null,
+      mode: 'standin',
+    };
+    const targetSnap: { current: ElementPresentation } = {
+      current: { content: null, transition: targetTransition },
+    };
 
     registry.register(
       makeElement(
@@ -228,7 +257,7 @@ describe('TransitionCoordinator presentation freezing', () => {
           ref: refWithMetrics({ pageX: 0, pageY: 0, width: 100, height: 100 }),
           metrics: { pageX: 0, pageY: 0, width: 100, height: 100 },
         },
-        snap
+        targetSnap
       )
     );
 
@@ -240,8 +269,56 @@ describe('TransitionCoordinator presentation freezing', () => {
     });
 
     expect(session?.pairs).toHaveLength(1);
+    expect(session?.pairs[0]?.transition).toBe(liveTransition);
+    expect(session?.pairs[0]?.targetPresentation.transition).toBe(
+      targetTransition
+    );
     expect(coordinator.getHiddenElements().size).toBe(0);
   }, 5000);
+
+  test('backward pairing selects the departing detail transition', async () => {
+    const listTransition: SharedElementTransition = {
+      renderer: () => null,
+      mode: 'live',
+    };
+    const detailTransition: SharedElementTransition = {
+      renderer: () => null,
+      mode: 'live',
+    };
+    const register = (
+      screenId: string,
+      selectedTransition: SharedElementTransition
+    ) => {
+      const presentation = {
+        current: { content: null, transition: selectedTransition },
+      };
+      registry.register(
+        makeElement(
+          {
+            id: 'player',
+            groupId: 'group',
+            screenId,
+            metrics: { pageX: 0, pageY: 0, width: 100, height: 100 },
+          },
+          presentation
+        )
+      );
+    };
+    register('list', listTransition);
+    register('detail', detailTransition);
+
+    const backward = await coordinator.startTransition({
+      groupId: 'group',
+      sourceScreenId: 'detail',
+      targetScreenId: 'list',
+      direction: 'backward',
+    });
+
+    expect(backward?.pairs[0]?.transition).toBe(detailTransition);
+    expect(backward?.pairs[0]?.source.screenId).toBe('detail');
+    expect(backward?.pairs[0]?.target.screenId).toBe('list');
+    expect(coordinator.getHiddenElements().size).toBe(0);
+  });
 
   test('cancelTransition also releases hidden elements', async () => {
     const snap: { current: ElementPresentation } = {

--- a/src/core/TransitionOverlay.test.tsx
+++ b/src/core/TransitionOverlay.test.tsx
@@ -18,6 +18,12 @@ import {
   resumeVisibilityHandoff,
 } from './ElementVisibilityRegistry';
 import { TransitionOverlay } from './TransitionOverlay';
+import { makeLiveTransition } from '../transitions/makeLiveTransition';
+import type { LiveTransitionRendererProps } from '../types';
+
+jest.mock('react-native-teleport', () => ({
+  PortalHost: 'PortalHost',
+}));
 
 jest.mock('react-native-reanimated', () => ({
   ...jest.requireActual('../../__mocks__/react-native-reanimated'),
@@ -40,6 +46,105 @@ function visibleOpacity(node: ReactTestInstance): number {
   }
   return opacity;
 }
+
+test('renders frozen live metadata while preserving evolving shared refs', async () => {
+  const sourceLive = { value: 0 };
+  const targetLive = { value: 1 };
+  let received!: LiveTransitionRendererProps;
+  const transition = makeLiveTransition({
+    renderer: (props) => {
+      received = props;
+      return props.children;
+    },
+  });
+  const sourceMetrics = { pageX: 1, pageY: 2, width: 240, height: 160 };
+  const targetMetrics = { pageX: 3, pageY: 4, width: 280, height: 180 };
+  const unavailable = () => {
+    throw new Error('overlay must not recapture a presentation');
+  };
+  const source = {
+    id: 'player',
+    groupId: 'media',
+    screenId: 'list',
+    ref: () => null,
+    metrics: sourceMetrics,
+    getPresentation: unavailable,
+  };
+  const target = {
+    ...source,
+    screenId: 'detail',
+    metrics: targetMetrics,
+  };
+  const pair: ElementTransitionPair = {
+    id: 'player',
+    source,
+    target,
+    sourceMetrics,
+    targetMetrics,
+    sourcePresentation: {
+      content: 'must not leak',
+      transition,
+      metadata: { revision: 'source-captured', live: sourceLive },
+    },
+    targetPresentation: {
+      content: 'must not leak',
+      transition,
+      metadata: { revision: 'target-captured', live: targetLive },
+    },
+    transition,
+  };
+  const progress = { value: 0.4 } as TransitionSessionData['progress'];
+  const session: TransitionSessionData = {
+    id: 'live-session',
+    groupId: 'media',
+    sourceScreenId: 'list',
+    targetScreenId: 'detail',
+    state: 'active',
+    direction: 'backward',
+    progress,
+    pairs: [pair],
+  };
+  const handoff = {
+    value: { sessionId: session.id, completed: false },
+  };
+  let tree!: ReactTestRenderer;
+
+  try {
+    await act(async () => {
+      tree = create(
+        <TransitionOverlay
+          session={session}
+          progress={progress}
+          handoff={handoff as never}
+        />
+      );
+    });
+
+    expect(received.source).toMatchObject({
+      screenId: 'list',
+      metrics: sourceMetrics,
+      metadata: { revision: 'source-captured' },
+    });
+    expect(received.target).toMatchObject({
+      screenId: 'detail',
+      metrics: targetMetrics,
+      metadata: { revision: 'target-captured' },
+    });
+    expect(received.source).not.toHaveProperty('content');
+    expect(received.target).not.toHaveProperty('content');
+
+    sourceLive.value = 0.25;
+    targetLive.value = 0.75;
+    expect(
+      (received.source.metadata as { live: { value: number } }).live.value
+    ).toBe(0.25);
+    expect(
+      (received.target.metadata as { live: { value: number } }).live.value
+    ).toBe(0.75);
+  } finally {
+    await act(async () => tree?.unmount());
+  }
+});
 
 test.each(['forward', 'backward'] as const)(
   'keeps live content visible at %s completion until React reparents it',

--- a/src/core/TransitionOverlay.tsx
+++ b/src/core/TransitionOverlay.tsx
@@ -89,24 +89,28 @@ function StandInRenderer({
   const visibilityStyle = useAnimatedStyle(() => ({
     opacity: isLive || !handoff.value.completed ? 1 : 0,
   }));
+  const source = {
+    screenId: pair.source.screenId,
+    metrics: pair.sourceMetrics,
+    style: pair.sourcePresentation.style,
+    content: pair.sourcePresentation.content,
+    metadata: pair.sourcePresentation.metadata,
+  };
+  const target = {
+    screenId: pair.target.screenId,
+    metrics: pair.targetMetrics,
+    style: pair.targetPresentation.style,
+    content: pair.targetPresentation.content,
+    metadata: pair.targetPresentation.metadata,
+  };
   const rendererProps: SharedElementTransitionRendererProps = {
     id: pair.id,
     groupId: pair.source.groupId ?? pair.target.groupId ?? sessionGroupId,
     progress,
     direction,
     zIndex: getPairZIndex(pair),
-    source: {
-      screenId: pair.source.screenId,
-      metrics: pair.sourceMetrics,
-      style: pair.sourcePresentation.style,
-      content: pair.sourcePresentation.content,
-    },
-    target: {
-      screenId: pair.target.screenId,
-      metrics: pair.targetMetrics,
-      style: pair.targetPresentation.style,
-      content: pair.targetPresentation.content,
-    },
+    source,
+    target,
   };
 
   return (

--- a/src/core/liveHostNames.ts
+++ b/src/core/liveHostNames.ts
@@ -1,0 +1,24 @@
+export function getLiveDestinationHostName(
+  screenId: string,
+  id: string,
+  groupId?: string
+) {
+  return `screen-choreography:live:destination:${JSON.stringify([screenId, groupId, id])}`;
+}
+
+export function getLiveOverlayHostName(
+  sourceScreenId: string,
+  targetScreenId: string,
+  id: string,
+  groupId: string
+) {
+  return `screen-choreography:live:overlay:${JSON.stringify([sourceScreenId, targetScreenId, groupId, id])}`;
+}
+
+export function getLivePortalName(
+  screenId: string,
+  id: string,
+  groupId?: string
+) {
+  return `screen-choreography:live:${JSON.stringify([screenId, groupId, id])}`;
+}

--- a/src/entries/core.ts
+++ b/src/entries/core.ts
@@ -22,6 +22,10 @@ export {
 } from '../transitions/makeStretchTransition';
 export { textMorphTransition } from '../transitions/textMorphTransition';
 export {
+  makeLiveTransition,
+  type MakeLiveTransitionOptions,
+} from '../transitions/makeLiveTransition';
+export {
   resolveSurfaceStyle,
   type BoxShadowEntry,
   type SurfaceTransitionStyle,
@@ -48,6 +52,9 @@ export type {
   SharedElementTransitionRenderer,
   SharedElementTransitionRendererProps,
   SharedElementTransitionSide,
+  LiveTransition,
+  LiveTransitionRendererProps,
+  LiveTransitionSide,
   TransitionConfig,
   ChoreographyNavigationOptions,
   ChoreographyNavigationLineage,

--- a/src/entries/index.test.ts
+++ b/src/entries/index.test.ts
@@ -83,6 +83,24 @@ function getNavigationDependencies(filePath: string) {
 }
 
 describe('Public entry points', () => {
+  test.each(['core', 'reactNavigation', 'expoRouter'] as const)(
+    '%s exports the complete live transition API',
+    (entry) => {
+      expect([...getExports(entries[entry]).keys()]).toEqual(
+        expect.arrayContaining([
+          'LiveSharedElementProps',
+          'LiveSharedElementTargetProps',
+          'LiveTransition',
+          'LiveTransitionRendererProps',
+          'LiveTransitionSide',
+          'MakeLiveTransitionOptions',
+          'SharedElement',
+          'makeLiveTransition',
+        ])
+      );
+    }
+  );
+
   test.each(Object.entries(entries))(
     '%s contains only exports',
     (_entry, filePath) => {

--- a/src/entries/livePublicApi.test.ts
+++ b/src/entries/livePublicApi.test.ts
@@ -1,0 +1,102 @@
+import type { ComponentProps } from 'react';
+import { SharedElement } from '../components/SharedElement';
+import type {
+  LiveTransition,
+  LiveTransitionRendererProps,
+  LiveTransitionSide,
+  SharedElementTransitionSide,
+  SharedElementTransition,
+} from '../types';
+import type { SharedElementProps } from '../components/SharedElement';
+
+type Assert<T extends true> = T;
+type IsAssignable<From, To> = [From] extends [To] ? true : false;
+type IsRequired<T, Key extends keyof T> =
+  {} extends Pick<T, Key> ? false : true;
+type Not<T extends boolean> = T extends true ? false : true;
+
+type LiveOwnerProps = ComponentProps<typeof SharedElement.Live>;
+type LiveTargetProps = ComponentProps<typeof SharedElement.LiveTarget>;
+type OrdinarySharedElementProps = ComponentProps<typeof SharedElement>;
+
+const typeContract: [
+  Assert<Not<IsAssignable<SharedElementTransition, LiveTransition>>>,
+  Assert<Not<'content' extends keyof LiveTransitionSide ? true : false>>,
+  Assert<
+    Not<'presentationContent' extends keyof LiveTransitionSide ? true : false>
+  >,
+  Assert<Not<'metadata' extends keyof SharedElementProps ? true : false>>,
+  Assert<
+    Not<'presentationContent' extends keyof SharedElementProps ? true : false>
+  >,
+  Assert<
+    Not<'metadata' extends keyof OrdinarySharedElementProps ? true : false>
+  >,
+  Assert<
+    Not<
+      'presentationContent' extends keyof OrdinarySharedElementProps
+        ? true
+        : false
+    >
+  >,
+  Assert<
+    Not<'metadata' extends keyof SharedElementTransitionSide ? true : false>
+  >,
+  Assert<
+    Not<
+      'presentationContent' extends keyof SharedElementTransitionSide
+        ? true
+        : false
+    >
+  >,
+  Assert<IsRequired<LiveTransitionRendererProps, 'children'>>,
+  Assert<IsAssignable<null, LiveOwnerProps['children']>>,
+  Assert<
+    Not<
+      IsAssignable<
+        SharedElementTransition,
+        NonNullable<LiveOwnerProps['transition']>
+      >
+    >
+  >,
+  Assert<
+    Not<
+      IsAssignable<
+        SharedElementTransition,
+        NonNullable<LiveTargetProps['transition']>
+      >
+    >
+  >,
+] = [
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+  true,
+];
+
+test('live public types preserve their branded and content-free contract', () => {
+  expect(typeContract).toEqual([
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+  ]);
+});

--- a/src/transitions/makeLiveTransition.test.tsx
+++ b/src/transitions/makeLiveTransition.test.tsx
@@ -1,0 +1,222 @@
+import React from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+import type {
+  LiveTransitionRendererProps,
+  SharedElementTransitionRendererProps,
+  SharedElementTransitionSide,
+} from '../types';
+import { makeLiveTransition } from './makeLiveTransition';
+
+jest.mock('react-native-teleport', () => ({
+  PortalHost: 'PortalHost',
+}));
+
+const { PortalHost } = jest.requireMock('react-native-teleport') as {
+  PortalHost: React.ElementType;
+};
+
+const metrics = {
+  pageX: 11,
+  pageY: 22,
+  width: 33,
+  height: 44,
+};
+
+type AdapterRuntimeProps = Omit<
+  SharedElementTransitionRendererProps,
+  'source' | 'target'
+> & {
+  source: SharedElementTransitionSide & { metadata?: unknown };
+  target: SharedElementTransitionSide & { metadata?: unknown };
+};
+
+function rendererProps(
+  overrides: Partial<AdapterRuntimeProps> = {}
+): AdapterRuntimeProps {
+  return {
+    id: 'player',
+    groupId: 'media',
+    progress: { value: 0 } as SharedElementTransitionRendererProps['progress'],
+    direction: 'forward',
+    zIndex: 100,
+    source: {
+      screenId: 'feed:one',
+      metrics,
+      content: <React.Fragment>source presentation</React.Fragment>,
+      metadata: { label: 'source-v1' },
+    },
+    target: {
+      screenId: 'detail:two',
+      metrics: { pageX: 55, pageY: 66, width: 77, height: 88 },
+      content: <React.Fragment>target presentation</React.Fragment>,
+      metadata: { label: 'target-v1' },
+    },
+    ...overrides,
+  };
+}
+
+describe('makeLiveTransition', () => {
+  test('brands live mode and defaults zIndex to 100 while retaining explicit zero', () => {
+    const Renderer = () => null;
+
+    expect(makeLiveTransition({ renderer: Renderer })).toMatchObject({
+      mode: 'live',
+      zIndex: 100,
+    });
+    expect(makeLiveTransition({ renderer: Renderer, zIndex: 0 })).toMatchObject(
+      {
+        mode: 'live',
+        zIndex: 0,
+      }
+    );
+  });
+
+  test('injects the exact pair host and strips frozen presentation content', async () => {
+    const render = jest.fn((_props: LiveTransitionRendererProps) => null);
+    function Renderer(props: LiveTransitionRendererProps) {
+      render(props);
+      return props.children;
+    }
+    const transition = makeLiveTransition({ renderer: Renderer });
+    const props = rendererProps();
+    let tree!: ReactTestRenderer;
+
+    try {
+      await act(async () => {
+        tree = create(React.createElement(transition.renderer, props));
+      });
+
+      const received = render.mock.calls[0]![0];
+      expect(received).toMatchObject({
+        id: 'player',
+        groupId: 'media',
+        direction: 'forward',
+        zIndex: 100,
+        source: {
+          screenId: 'feed:one',
+          metrics,
+          metadata: { label: 'source-v1' },
+        },
+        target: {
+          screenId: 'detail:two',
+          metrics: { pageX: 55, pageY: 66, width: 77, height: 88 },
+          metadata: { label: 'target-v1' },
+        },
+      });
+      expect(received.progress).toBe(props.progress);
+      expect(received.source).not.toHaveProperty('content');
+      expect(received.target).not.toHaveProperty('content');
+
+      const host = tree.root.findByType(PortalHost);
+      expect(host.props.name).toBe(
+        'screen-choreography:live:overlay:["feed:one","detail:two","media","player"]'
+      );
+      expect(host.props.style).toMatchObject({
+        position: 'absolute',
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      });
+
+      props.progress.value = 0.75;
+      expect(received.progress.value).toBe(0.75);
+    } finally {
+      await act(async () => tree?.unmount());
+    }
+  });
+
+  test('keeps geometry and metadata independent for source and target', async () => {
+    let received!: LiveTransitionRendererProps;
+    function Renderer(props: LiveTransitionRendererProps) {
+      received = props;
+      return props.children;
+    }
+    const transition = makeLiveTransition({ renderer: Renderer, zIndex: 314 });
+    const props = rendererProps({ direction: 'backward', zIndex: 314 });
+    let tree!: ReactTestRenderer;
+
+    try {
+      await act(async () => {
+        tree = create(React.createElement(transition.renderer, props));
+      });
+
+      expect(received.source.metrics).toBe(props.source.metrics);
+      expect(received.target.metrics).toBe(props.target.metrics);
+      expect(received.source.metrics).not.toEqual(received.target.metrics);
+      expect(received.source.metadata).toBe(props.source.metadata);
+      expect(received.target.metadata).toBe(props.target.metadata);
+      expect(received.direction).toBe('backward');
+      expect(received.zIndex).toBe(314);
+    } finally {
+      await act(async () => tree?.unmount());
+    }
+  });
+
+  test('keeps the custom renderer mounted across ordinary presentation updates', async () => {
+    const mounts = jest.fn();
+    const unmounts = jest.fn();
+    function Renderer({ children }: LiveTransitionRendererProps) {
+      React.useEffect(() => {
+        mounts();
+        return unmounts;
+      }, []);
+      return children;
+    }
+    const transition = makeLiveTransition({ renderer: Renderer });
+    const first = rendererProps();
+    const second = rendererProps({
+      source: {
+        ...first.source,
+        content: <React.Fragment>changed presentation</React.Fragment>,
+        metadata: { label: 'source-v2' },
+      },
+    });
+    let tree!: ReactTestRenderer;
+
+    try {
+      await act(async () => {
+        tree = create(React.createElement(transition.renderer, first));
+      });
+      await act(async () => {
+        tree.update(React.createElement(transition.renderer, second));
+      });
+
+      expect(mounts).toHaveBeenCalledTimes(1);
+      expect(unmounts).not.toHaveBeenCalled();
+    } finally {
+      await act(async () => tree?.unmount());
+    }
+    expect(unmounts).toHaveBeenCalledTimes(1);
+  });
+
+  test('names hosts collision-safely across screen pairs and groups', async () => {
+    function Renderer({ children }: LiveTransitionRendererProps) {
+      return children;
+    }
+    const transition = makeLiveTransition({ renderer: Renderer });
+    const cases = [
+      rendererProps(),
+      rendererProps({
+        source: { ...rendererProps().source, screenId: 'feed' },
+        target: { ...rendererProps().target, screenId: 'one:detail:two' },
+      }),
+      rendererProps({ groupId: 'media:alternate' }),
+    ];
+    const names: string[] = [];
+
+    for (const props of cases) {
+      let tree!: ReactTestRenderer;
+      try {
+        await act(async () => {
+          tree = create(React.createElement(transition.renderer, props));
+        });
+        names.push(tree.root.findByType(PortalHost).props.name);
+      } finally {
+        await act(async () => tree?.unmount());
+      }
+    }
+
+    expect(new Set(names).size).toBe(cases.length);
+  });
+});

--- a/src/transitions/makeLiveTransition.tsx
+++ b/src/transitions/makeLiveTransition.tsx
@@ -1,0 +1,160 @@
+import type { ComponentType } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  interpolate,
+  useAnimatedStyle,
+  useDerivedValue,
+} from 'react-native-reanimated';
+import { PortalHost } from 'react-native-teleport';
+import { getExpansionProgress } from '../core/expansionProgress';
+import { getLiveOverlayHostName } from '../core/liveHostNames';
+import type {
+  LiveTransition,
+  LiveTransitionRendererProps,
+  SharedElementTransitionRendererProps,
+  SharedElementTransitionSide,
+} from '../types';
+
+interface LiveTransitionAdapterSide extends SharedElementTransitionSide {
+  metadata?: unknown;
+}
+
+interface LiveTransitionAdapterRendererProps extends Omit<
+  SharedElementTransitionRendererProps,
+  'source' | 'target'
+> {
+  source: LiveTransitionAdapterSide;
+  target: LiveTransitionAdapterSide;
+}
+
+export interface MakeLiveTransitionOptions {
+  /** Must render the supplied host children exactly once throughout the session. */
+  renderer: ComponentType<LiveTransitionRendererProps>;
+  /** Overlay stacking order. Defaults to 100, including for custom motion. */
+  zIndex?: number;
+}
+
+/**
+ * Adapts custom motion while the library owns the sole live portal host.
+ * Create outside render or memoize, and reuse on both live endpoints.
+ */
+export function makeLiveTransition({
+  renderer: Renderer,
+  zIndex = 100,
+}: MakeLiveTransitionOptions): LiveTransition {
+  function LiveTransitionAdapter({
+    id,
+    groupId,
+    progress,
+    direction,
+    zIndex: rendererZIndex,
+    source,
+    target,
+  }: LiveTransitionAdapterRendererProps) {
+    const sourceSide = {
+      screenId: source.screenId,
+      metrics: source.metrics,
+      style: source.style,
+      metadata: source.metadata,
+    };
+    const targetSide = {
+      screenId: target.screenId,
+      metrics: target.metrics,
+      style: target.style,
+      metadata: target.metadata,
+    };
+
+    return (
+      <Renderer
+        id={id}
+        groupId={groupId}
+        progress={progress}
+        direction={direction}
+        zIndex={rendererZIndex}
+        source={sourceSide}
+        target={targetSide}
+      >
+        <PortalHost
+          name={getLiveOverlayHostName(
+            source.screenId,
+            target.screenId,
+            id,
+            groupId
+          )}
+          style={styles.liveHost}
+        />
+      </Renderer>
+    );
+  }
+
+  return {
+    mode: 'live',
+    zIndex,
+    renderer: LiveTransitionAdapter,
+  } as LiveTransition;
+}
+
+function BoundsLiveTransition({
+  progress,
+  direction,
+  source,
+  target,
+  zIndex,
+  children,
+}: LiveTransitionRendererProps) {
+  const sourceX = source.metrics.pageX;
+  const sourceY = source.metrics.pageY;
+  const sourceWidth = source.metrics.width;
+  const sourceHeight = source.metrics.height;
+  const targetX = target.metrics.pageX;
+  const targetY = target.metrics.pageY;
+  const targetWidth = target.metrics.width;
+  const targetHeight = target.metrics.height;
+  const timeline = useDerivedValue(() =>
+    direction === 'backward' ? 1 - progress.value : progress.value
+  );
+  const animatedStyle = useAnimatedStyle(() => {
+    const heightProgress = getExpansionProgress(
+      timeline.value,
+      sourceHeight,
+      targetHeight
+    );
+
+    return {
+      left: interpolate(timeline.value, [0, 1], [sourceX, targetX], 'clamp'),
+      top: interpolate(timeline.value, [0, 1], [sourceY, targetY], 'clamp'),
+      width: interpolate(
+        timeline.value,
+        [0, 1],
+        [sourceWidth, targetWidth],
+        'clamp'
+      ),
+      height: interpolate(
+        heightProgress,
+        [0, 1],
+        [sourceHeight, targetHeight],
+        'clamp'
+      ),
+    };
+  });
+
+  return (
+    <Animated.View style={[styles.liveOverlayHost, { zIndex }, animatedStyle]}>
+      {children}
+    </Animated.View>
+  );
+}
+
+export const defaultLiveTransition = makeLiveTransition({
+  renderer: BoundsLiveTransition,
+});
+
+const styles = StyleSheet.create({
+  liveOverlayHost: {
+    position: 'absolute',
+    overflow: 'hidden',
+  },
+  liveHost: {
+    ...StyleSheet.absoluteFill,
+  },
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from 'react';
+import type { ComponentType, ReactElement, ReactNode } from 'react';
 import type { AnimatedRef, SharedValue } from 'react-native-reanimated';
 import type { ViewStyle } from 'react-native';
 
@@ -46,6 +46,31 @@ export interface SharedElementTransition {
   mode?: 'standin' | 'live';
 }
 
+declare const liveTransitionBrand: unique symbol;
+
+/** A live transition created by `makeLiveTransition`. */
+export interface LiveTransition extends SharedElementTransition {
+  readonly [liveTransitionBrand]: true;
+  mode: 'live';
+}
+
+export interface LiveTransitionSide extends Omit<
+  SharedElementTransitionSide,
+  'content'
+> {
+  metadata?: unknown;
+}
+
+export interface LiveTransitionRendererProps extends Omit<
+  SharedElementTransitionRendererProps,
+  'source' | 'target'
+> {
+  source: LiveTransitionSide;
+  target: LiveTransitionSide;
+  /** The library-owned live portal host. Render it exactly once. */
+  children: ReactElement;
+}
+
 export type NodeHandleRef = React.RefObject<any> | (() => any);
 
 /** Frozen renderer input captured at session start. */
@@ -53,6 +78,7 @@ export interface ElementPresentation {
   content: ReactNode;
   style?: ViewStyle;
   transition: SharedElementTransition;
+  metadata?: unknown;
 }
 
 export interface RegisteredElement {


### PR DESCRIPTION
Live shared elements currently force built-in bounds interpolation and couple the payload layout to its measured endpoints. This adds custom motion while the library retains ownership of one mounted subtree and its portal lifecycle.

- `makeLiveTransition` supplies a library-owned host as required renderer children and preserves live mode and the default zIndex of 100.
- `portalStyle` and `hostStyle` separate content and receiving-host layout from endpoint measurement.
- Explicit endpoint metadata replaces any need to inspect React child props. Metadata references are captured per session; referenced SharedValues can keep changing.
- Both live endpoints accept the same transition object for consistent forward and backward motion. Omitted options retain built-in behavior.

The shared Music example demonstrates a stateful 160×64 panel moving into a 280×112 endpoint without changing its layout or resetting its counter. Documentation explains host ownership, geometry continuity, renderer identity, metadata, and reverse configuration.

Validation:

- Node 24.13.0 / Yarn 4.11.0: immutable install, lint, typecheck, `yarn test --runInBand` (33 suites / 239 tests), prepare, and package archive all passed. Lint retains one existing GalleryDetailScreen warning.
- React Navigation and Expo Router example typechecks passed.
- Both examples built for iOS and Android with their own matching native dependencies.
- Manual iOS simulator and Android emulator checks through both integrations retained the panel instance and counter through forward navigation, interactive cancellation, back navigation, and repeated opens. Local recordings were inspected for handoff continuity.
- Regression coverage includes namespaced hosts, default/explicit stacking, independent dimensions, stable registration/renderer identity, metadata capture, cancellation/interruption/repetition, and public type/export contracts.

GitHub checks still need to run on the PR commit.
